### PR TITLE
TypeScript の設定見直し

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "noUnusedLocals": true,
     "target": "es5",
     "typeRoots": [
       "node_modules/@types"

--- a/tslint.json
+++ b/tslint.json
@@ -88,7 +88,6 @@
     "no-trailing-whitespace": true,
     "no-unnecessary-initializer": true,
     "no-unused-expression": true,
-    "no-unused-variable": true,
     "no-use-before-declare": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,


### PR DESCRIPTION
- TSLint のオプションである no-unused-variable が deprecated になっているので削除
- 代わりに同じチェックを tsconfig の方で実施するように noUnusedLocals を有効化