### PR TITLE
プロジェクト名を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 | プロジェクト名 | 略名  | Project Type | 説明                                                                                  |
 |----------------|-------|--------------|---------------------------------------------------------------------------------------|
-| afte-tutorial  | at    | Application  | [Angular After Tutorial](https://gitbook.lacolaco.net/angular-after-tutorial/) の写経 |
+| after-tutorial | at    | Application  | [Angular After Tutorial](https://gitbook.lacolaco.net/angular-after-tutorial/) の写経 |
 | anything       | anytn | Application  | なんでも                                                                              |
 | counter        | cnt   | Application  | カウンターアプリ(NgRx お試し)                                                         |
 | gadget         | lib   | Library      | 共通コンポーネント                                                                    |


### PR DESCRIPTION
`after`の`r`が抜けていたため追加しました